### PR TITLE
Updated metrics.py, exp_ForecastPFN.py, exp_transformer_metalearn.py, requirements.txt

### DIFF
--- a/benchmark/exp/exp_ForecastPFN.py
+++ b/benchmark/exp/exp_ForecastPFN.py
@@ -88,10 +88,10 @@ class Exp_ForecastPFN(Exp_Basic):
                 target = tf.pad(x_mark.cpu(), [[100-x.shape[0], 0], [0, 0]])
                 history = tf.pad(history, [[100-x.shape[0], 0], [0, 0]])
 
-            history = tf.repeat(tf.expand_dims(history, axis=0), [
-                                horizon], axis=0)[:, :, 0]
-            ts = tf.repeat(tf.expand_dims(
-                target, axis=0), [horizon], axis=0)
+            # Ensure 'history' is cast to float32
+            history = tf.cast(history, tf.float32)
+            history = tf.repeat(tf.expand_dims(history, axis=0), [horizon], axis=0)[:, :, 0]
+            ts = tf.repeat(tf.expand_dims(target, axis=0), [horizon], axis=0)
 
         else:
             ts = tf.convert_to_tensor(x_mark.unsqueeze(0).repeat(
@@ -133,8 +133,8 @@ class Exp_ForecastPFN(Exp_Basic):
             list(test_data.data_stamp_original['date']))
         if test:
             print('loading model')
-            pretrained = tf.keras.models.load_model(
-                self.args.model_path, custom_objects={'smape': smape})
+            pretrained = tf.saved_model.load(
+                self.args.model_path)
 
         preds = []
         trues = []
@@ -163,5 +163,10 @@ class Exp_ForecastPFN(Exp_Basic):
         self.test_timer.total_time = timer
         print('total time:')
         print(timer)
+        
+        preds_all = np.concatenate([np.array(p).reshape(-1) for p in preds])
+        trues_all = np.concatenate([np.array(t).reshape(-1) for t in trues])
+        smape_value = smape(trues_all, preds_all)
+        print("SMAPE:", smape_value.numpy())
 
         return self._save_test_data(setting, preds, trues)

--- a/benchmark/exp/exp_transformer_metalearn.py
+++ b/benchmark/exp/exp_transformer_metalearn.py
@@ -1,7 +1,7 @@
 import time
 import yaml
 import sys
-sys.path.append('/home/ubuntu/ForecastPFN/academic_comparison/')
+sys.path.append('/home/ubuntu/ForecastPFN/academic_comparison/') # Change /home/ubuntu/ path according to local environment
 
 import os
 import time
@@ -20,8 +20,8 @@ from transformer_models.models import FEDformer, Autoformer, Informer, Transform
 from utils.tools import EarlyStopping, TimeBudget, adjust_learning_rate, visual
 from utils.metrics import metric
 
-sys.path.append('/home/ubuntu/ForecastPFN/src/')
-sys.path.append('/home/ubuntu/ForecastPFN/src/training/')
+sys.path.append('/home/ubuntu/ForecastPFN/src/') # Change /home/ubuntu/ path according to local environment
+sys.path.append('/home/ubuntu/ForecastPFN/src/training/') # Change /home/ubuntu/ path according to local environment
 from training.create_train_test_df import create_train_test_df
 import tensorflow as tf
 

--- a/benchmark/utils/metrics.py
+++ b/benchmark/utils/metrics.py
@@ -1,6 +1,6 @@
 import numpy as np
 import tensorflow as tf
-from keras import backend
+from tensorflow.keras import backend
 
 
 def RSE(pred, true):

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ pickleshare==0.7.5
 Pillow==9.5.0
 pip==23.0.1
 platformdirs==3.2.0
-pmdarima==2.0.3
+pmdarima==2.0.4
 prompt-toolkit==3.0.38
 prophet==1.1
 protobuf==3.19.6
@@ -103,7 +103,7 @@ tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
 tensorflow==2.9.3
 tensorflow-estimator==2.9.0
-tensorflow-io==0.26.0
+tensorflow-io==0.37.1
 tensorflow-io-gcs-filesystem==0.26.0
 termcolor==2.2.0
 threadpoolctl==3.1.0


### PR DESCRIPTION
A) requirements.txt:
1. pmdarima==2.0.3 --> pmdarima==2.0.4
2. tensorflow-io==0.26.0 --> tensorflow-io==0.37.1

B) ForecastPFN/benchmark/utils/metrics.py:
1. from keras import backend --> from tensorflow.keras import backend

C) ForecastPFN/benchmark/exp/exp_ForecastPFN.py:
1. Casted history variable to float32 to avoid error
2. Used tf.saved_model.load() instead of tf.keras.models.load_model() as .pb models are not compatible with Keras3
3. Added code to calculate SMAPE at the bottom

D) ForecastPFN/benchmark/exp/exp_transformer_metalearn.py
1. Added comments near the imports where changing the sys.path.append() path is important to avoid local development errors




